### PR TITLE
feat: initial offline gtd app skeleton

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.pnpm-store
+pnpm-lock.yaml
+.DS_Store
+playwright-report

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# gtd-app
+# GTD App
+
+Offline-first PWA for managing tasks following Getting Things Done.
+
+## Setup
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Scripts
+
+- `pnpm dev` – start web app
+- `pnpm build` – build web app
+- `pnpm test` – run unit tests
+- `pnpm e2e` – run Playwright smoke test
+- `pnpm seed` – seed IndexedDB with sample data
+
+## Architecture
+
+Monorepo layout:
+
+- `packages/core` – domain models, priority util, quick-add parser, selectors
+- `packages/storage` – Dexie database and repositories, seed script
+- `apps/web` – React UI using Zustand state
+- `e2e` – Playwright tests
+
+## Design notes
+
+Storage access is abstracted through repository interfaces. To extend to Electron with SQLite in v0.2, create new adapters implementing the same repos using a SQLite driver and replace the imports from `@storage/repositories`.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GTD App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@apps/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "GTD App",
+  "short_name": "GTD",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Offline GTD app",
+  "icons": []
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('install', (e) => {
+  e.waitUntil(caches.open('gtd-cache').then((cache) => cache.add('/')));
+});
+self.addEventListener('fetch', (e) => {
+  e.respondWith(
+    caches.match(e.request).then((resp) => resp || fetch(e.request))
+  );
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,23 @@
+import { Link, Route, Routes } from 'react-router-dom';
+import Inbox from './routes/Inbox';
+import Today from './routes/Today';
+import Week from './routes/Week';
+
+export default function App() {
+  return (
+    <div className="app">
+      <nav>
+        <Link to="/inbox">Inbox</Link> | <Link to="/today">Today</Link> |{' '}
+        <Link to="/week">Week</Link>
+      </nav>
+      <main>
+        <Routes>
+          <Route path="/" element={<Inbox />} />
+          <Route path="/inbox" element={<Inbox />} />
+          <Route path="/today" element={<Today />} />
+          <Route path="/week" element={<Week />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/QuickAdd.tsx
+++ b/apps/web/src/components/QuickAdd.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { useStore } from '../store';
+
+export default function QuickAdd() {
+  const [text, setText] = useState('');
+  const add = useStore((s) => s.addFromInput);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (text.trim()) {
+          add(text);
+          setText('');
+        }
+      }}
+    >
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Quick add"
+      />
+    </form>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,17 @@
+import '@vitejs/plugin-react/preamble';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apps/web/src/routes/Inbox.tsx
+++ b/apps/web/src/routes/Inbox.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useStore } from '../store';
+import QuickAdd from '../components/QuickAdd';
+
+export default function Inbox() {
+  const tasks = useStore((s) => s.tasks);
+  const load = useStore((s) => s.load);
+  useEffect(() => {
+    load();
+  }, [load]);
+  return (
+    <div>
+      <h1>Inbox</h1>
+      <QuickAdd />
+      <ul>
+        {tasks.map((t) => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/routes/Today.tsx
+++ b/apps/web/src/routes/Today.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useStore, selectToday } from '../store';
+
+export default function Today() {
+  const tasks = useStore((s) => selectToday(s.tasks));
+  const load = useStore((s) => s.load);
+  useEffect(() => {
+    load();
+  }, [load]);
+  return (
+    <div>
+      <h1>Today</h1>
+      <ul>
+        {tasks.map((t) => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/routes/Week.tsx
+++ b/apps/web/src/routes/Week.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useStore, selectWeek } from '../store';
+
+export default function Week() {
+  const tasks = useStore((s) => selectWeek(s.tasks));
+  const load = useStore((s) => s.load);
+  useEffect(() => {
+    load();
+  }, [load]);
+  return (
+    <div>
+      <h1>Week</h1>
+      <ul>
+        {tasks.map((t) => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1,0 +1,41 @@
+import create from 'zustand';
+import { Task } from '@core/types';
+import { parseQuickAdd, selectToday as todaySelector, selectWeek as weekSelector } from '@core';
+import { taskRepo } from '@storage/repositories';
+
+interface State {
+  tasks: Task[];
+  load: () => Promise<void>;
+  addFromInput: (text: string) => Promise<void>;
+}
+
+export const useStore = create<State>((set) => ({
+  tasks: [],
+  load: async () => {
+    const tasks = await taskRepo.all();
+    set({ tasks });
+  },
+  addFromInput: async (text: string) => {
+    const partial = parseQuickAdd(text);
+    const now = new Date().toISOString();
+    const task: Task = {
+      id: Math.random().toString(36).slice(2),
+      title: partial.title,
+      status: partial.status,
+      stakeholderIds: partial.stakeholderIds ?? [],
+      contextTags: partial.contextTags ?? [],
+      projectId: partial.projectId,
+      dueAt: partial.dueAt,
+      priority: 0,
+      energy: 'med',
+      createdAt: now,
+      updatedAt: now,
+      source: 'manual',
+    };
+    await taskRepo.add(task);
+    set((s) => ({ tasks: [...s.tasks, task] }));
+  },
+}));
+
+export const selectToday = (tasks: Task[]) => todaySelector(tasks);
+export const selectWeek = (tasks: Task[]) => weekSelector(tasks);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@core': path.resolve(__dirname, '../../packages/core/src'),
+      '@storage': path.resolve(__dirname, '../../packages/storage/src'),
+    },
+  },
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'pnpm --filter @apps/web dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  testDir: '.',
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('quick add flow', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.fill('input[placeholder="Quick add"]', 'smoke task');
+  await page.press('input[placeholder="Quick add"]', 'Enter');
+  await expect(page.locator('li', { hasText: 'smoke task' })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "gtd-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "pnpm --filter @apps/web dev",
+    "build": "pnpm --filter @apps/web build",
+    "test": "vitest",
+    "e2e": "playwright test",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "seed": "tsx packages/storage/src/seed.ts"
+  },
+  "workspaces": ["packages/*", "apps/*", "e2e"],
+  "dependencies": {
+    "dexie": "^4.0.0",
+    "zustand": "^4.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.0.0",
+    "date-fns": "^2.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "prettier": "^3.0.0",
+    "tsx": "^4.0.0",
+    "fake-indexeddb": "^6.0.0",
+    "playwright": "^1.41.0"
+  },
+  "pnpm": {
+    "packageManager": "pnpm@8"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@core",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './priority';
+export * from './parser';
+export * from './selectors';

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,0 +1,82 @@
+import { addDays, nextDay, parse as parseDate, set } from 'date-fns';
+import { Task } from './types';
+
+export interface ParsedTask extends Partial<Task> {
+  title: string;
+}
+
+const dayMap: Record<string, number> = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function parseNaturalDate(token: string, now = new Date()): Date | undefined {
+  const lower = token.toLowerCase();
+  if (lower === 'today') return set(now, { hours: 17, minutes: 0, seconds: 0, milliseconds: 0 });
+  if (lower === 'tomorrow') return set(addDays(now, 1), { hours: 17, minutes: 0, seconds: 0, milliseconds: 0 });
+  if (dayMap[lower]?.toString()) return nextDay(now, dayMap[lower]);
+  const inMatch = lower.match(/^in\s+(\d+)([dw])$/);
+  if (inMatch) {
+    const qty = parseInt(inMatch[1], 10);
+    const unit = inMatch[2];
+    return unit === 'd' ? addDays(now, qty) : addDays(now, qty * 7);
+  }
+  // yyyy-mm-dd or yyyy-mm-dd hh:mm
+  const parsed = parseDate(token, 'yyyy-MM-dd', now);
+  if (!isNaN(parsed.getTime())) return parsed;
+  return undefined;
+}
+
+/**
+ * Quick-add parser. It is intentionally deterministic and very small.
+ */
+export function parseQuickAdd(input: string, now = new Date()): ParsedTask {
+  let title = input.trim();
+  const stakeholders: string[] = [];
+  const tags: string[] = [];
+  let project: string | undefined;
+  let status: Task['status'] = 'inbox';
+  let dueAt: string | undefined;
+
+  title = title.replace(/@([\w-]+)/g, (_, m) => {
+    stakeholders.push(m);
+    return '';
+  });
+
+  title = title.replace(/\+([\w-]+)/g, (_, m) => {
+    tags.push(m);
+    return '';
+  });
+
+  title = title.replace(/#([\w-]+)/g, (_, m) => {
+    project = m;
+    return '';
+  });
+
+  title = title.replace(/!(\w+)/g, (_, m) => {
+    if (m === 'waiting') status = 'waiting';
+    if (m === 'risk') tags.push('risk');
+    return '';
+  });
+
+  const dateMatch = title.match(/\b(by|on)?\s*(today|tomorrow|mon|tue|wed|thu|fri|sat|sun|in\s+\d+[dw]|\d{4}-\d{2}-\d{2})\b/i);
+  if (dateMatch) {
+    const d = parseNaturalDate(dateMatch[2], now);
+    if (d) dueAt = d.toISOString();
+    title = title.replace(dateMatch[0], '').trim();
+  }
+
+  return {
+    title: title.trim(),
+    stakeholderIds: stakeholders,
+    contextTags: tags,
+    projectId: project,
+    status,
+    dueAt,
+  } as ParsedTask;
+}

--- a/packages/core/src/priority.ts
+++ b/packages/core/src/priority.ts
@@ -1,0 +1,34 @@
+import { differenceInCalendarDays } from 'date-fns';
+import { TaskStatus } from './types';
+
+export interface PriorityInput {
+  impact: number;
+  dueAt?: string;
+  deferUntil?: string;
+  status: TaskStatus;
+}
+
+/**
+ * Simple priority heuristic inspired by GTD. Higher numbers mean higher priority.
+ * Impact is scaled 0-5. Time urgency boosts priority as due date nears.
+ * Waiting tasks get a penalty so they fall down the list.
+ */
+export function computePriority(input: PriorityInput, now = new Date()): number {
+  const { impact, dueAt, deferUntil, status } = input;
+  let score = impact * 2; // base weight
+
+  if (deferUntil && new Date(deferUntil) > now) {
+    // deferred in the future => very low priority
+    score -= 5;
+  }
+
+  if (dueAt) {
+    const days = differenceInCalendarDays(new Date(dueAt), now);
+    if (days < 0) score += 5; // overdue
+    else score += Math.max(0, 3 - days); // within next 3 days
+  }
+
+  if (status === 'waiting') score -= 4;
+
+  return score;
+}

--- a/packages/core/src/selectors.ts
+++ b/packages/core/src/selectors.ts
@@ -1,0 +1,21 @@
+import { Task } from './types';
+import { isWithinInterval, startOfDay, endOfDay, endOfWeek } from 'date-fns';
+
+export function selectToday(tasks: Task[], now = new Date()): Task[] {
+  return tasks.filter((t) =>
+    ['next', 'waiting'].includes(t.status) &&
+    (!t.deferUntil || new Date(t.deferUntil) <= now) &&
+    (!t.dueAt || isWithinInterval(new Date(t.dueAt), { start: startOfDay(now), end: endOfDay(now) }))
+  );
+}
+
+export function selectWeek(tasks: Task[], now = new Date()): Task[] {
+  const start = startOfDay(now);
+  const end = endOfWeek(now, { weekStartsOn: 1 });
+  return tasks.filter(
+    (t) =>
+      ['next', 'waiting'].includes(t.status) &&
+      t.dueAt &&
+      isWithinInterval(new Date(t.dueAt), { start, end })
+  );
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,89 @@
+export type TaskStatus = 'inbox' | 'next' | 'waiting' | 'someday' | 'done';
+export type EnergyLevel = 'low' | 'med' | 'high';
+export type TaskSource = 'manual' | 'email' | 'url';
+
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  projectId?: string;
+  stakeholderIds: string[];
+  dueAt?: string;
+  deferUntil?: string;
+  estimateMin?: number;
+  energy: EnergyLevel;
+  priority: number;
+  contextTags: string[];
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  source: TaskSource;
+}
+
+export type Rag = 'red' | 'amber' | 'green';
+
+export interface Project {
+  id: string;
+  name: string;
+  goal?: string;
+  rag: Rag;
+  nextActionTaskId?: string;
+  milestones: { id: string; title: string; dueAt?: string }[];
+  lastReviewedAt?: string;
+}
+
+export interface Stakeholder {
+  id: string;
+  name: string;
+  role?: string;
+  org?: string;
+  email?: string;
+  phone?: string;
+  lastTouchAt?: string;
+  nextTouchAt?: string;
+  touches: { at: string; note: string }[];
+}
+
+export interface Risk {
+  id: string;
+  projectId: string;
+  title: string;
+  probability: number; // 0-1
+  impact: 1 | 2 | 3 | 4 | 5;
+  score: number;
+  mitigation?: string;
+  ownerStakeholderId?: string;
+  dueAt?: string;
+  status: 'open' | 'mitigating' | 'closed';
+}
+
+export interface ReviewSession {
+  id: string;
+  type: 'daily' | 'weekly' | 'monthly';
+  plannedTop3: string[];
+  notes?: string;
+  completedAt: string;
+}
+
+export interface Note {
+  id: string;
+  title: string;
+  body: string;
+  linkedIds: string[];
+  createdAt: string;
+}
+
+export interface Tag {
+  id: string;
+  name: string;
+  kind: 'context' | 'domain';
+}
+
+export interface Attachment {
+  id: string;
+  taskId: string;
+  urlOrBlobRef: string;
+  mime: string;
+  title?: string;
+}

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { parseQuickAdd } from '../src/parser';
+
+const base = new Date('2023-06-30T09:00:00Z'); // Friday
+
+describe('quick-add parser', () => {
+  it('extracts stakeholder and project and tag', () => {
+    const r = parseQuickAdd('Meet @Bob about #Alpha +call', base);
+    expect(r.stakeholderIds).toEqual(['Bob']);
+    expect(r.projectId).toBe('Alpha');
+    expect(r.contextTags).toContain('call');
+  });
+
+  it('sets waiting status', () => {
+    const r = parseQuickAdd('Ping @Sue !waiting', base);
+    expect(r.status).toBe('waiting');
+  });
+
+  it('parses today', () => {
+    const r = parseQuickAdd('Do it today', base);
+    expect(r.dueAt?.startsWith('2023-06-30')).toBe(true);
+  });
+
+  it('parses tomorrow', () => {
+    const r = parseQuickAdd('Do it tomorrow', base);
+    expect(r.dueAt?.startsWith('2023-07-01')).toBe(true);
+  });
+
+  it('parses weekday next week', () => {
+    const r = parseQuickAdd('Call on mon', base);
+    expect(r.dueAt?.startsWith('2023-07-03')).toBe(true);
+  });
+
+  it('parses in 2d', () => {
+    const r = parseQuickAdd('Finish in 2d', base);
+    expect(r.dueAt?.startsWith('2023-07-02')).toBe(true);
+  });
+
+  it('parses explicit date', () => {
+    const r = parseQuickAdd('Report 2023-12-25', base);
+    expect(r.dueAt?.startsWith('2023-12-25')).toBe(true);
+  });
+
+  it('marks risk', () => {
+    const r = parseQuickAdd('Check !risk', base);
+    expect(r.contextTags).toContain('risk');
+  });
+
+  it('handles multiple tags and stakeholders', () => {
+    const r = parseQuickAdd('Discuss @A @B +deep +work', base);
+    expect(r.stakeholderIds.length).toBe(2);
+    expect(r.contextTags.length).toBe(2);
+  });
+
+  it('trims leftover text', () => {
+    const r = parseQuickAdd('  Plan   #X  ', base);
+    expect(r.title).toBe('Plan');
+  });
+
+  it('keeps unknown tokens', () => {
+    const r = parseQuickAdd('note $dollar', base);
+    expect(r.title).toBe('note $dollar');
+  });
+
+  it('ignores unmatched date', () => {
+    const r = parseQuickAdd('task someday', base);
+    expect(r.dueAt).toBeUndefined();
+  });
+
+  it('supports "by" keyword', () => {
+    const r = parseQuickAdd('submit report by Tue', base);
+    expect(r.dueAt?.startsWith('2023-07-04')).toBe(true);
+  });
+
+  it('project at end', () => {
+    const r = parseQuickAdd('Do thing #Zeta', base);
+    expect(r.projectId).toBe('Zeta');
+  });
+
+  it('waiting and date', () => {
+    const r = parseQuickAdd('Get reply !waiting tomorrow', base);
+    expect(r.status).toBe('waiting');
+    expect(r.dueAt?.startsWith('2023-07-01')).toBe(true);
+  });
+
+  it('handles uppercase tokens', () => {
+    const r = parseQuickAdd('EMAIL @JOE BY FRI #OPS', base);
+    expect(r.stakeholderIds[0]).toBe('JOE');
+    expect(r.dueAt?.startsWith('2023-07-07')).toBe(true);
+  });
+});

--- a/packages/core/tests/priority.test.ts
+++ b/packages/core/tests/priority.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { computePriority } from '../src/priority';
+
+const base = new Date('2023-01-01T00:00:00Z');
+
+describe('priority', () => {
+  it('uses impact', () => {
+    expect(computePriority({ impact: 3, status: 'inbox' }, base)).toBe(6);
+  });
+
+  it('boosts near due date', () => {
+    expect(
+      computePriority({ impact: 1, status: 'next', dueAt: '2023-01-02' }, base)
+    ).toBeGreaterThan(2);
+  });
+
+  it('penalizes waiting', () => {
+    expect(computePriority({ impact: 1, status: 'waiting' }, base)).toBeLessThan(2);
+  });
+
+  it('boosts overdue', () => {
+    expect(
+      computePriority({ impact: 1, status: 'next', dueAt: '2022-12-30' }, base)
+    ).toBeGreaterThan(6);
+  });
+
+  it('penalizes deferred future', () => {
+    expect(
+      computePriority({ impact: 3, status: 'next', deferUntil: '2023-01-10' }, base)
+    ).toBeLessThan(6);
+  });
+});

--- a/packages/core/tests/selectors.test.ts
+++ b/packages/core/tests/selectors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { selectToday, selectWeek } from '../src/selectors';
+import { Task } from '../src/types';
+
+const base = new Date('2023-07-05T12:00:00Z'); // Wednesday
+
+const tasks: Task[] = [
+  {
+    id: '1',
+    title: 'today task',
+    status: 'next',
+    stakeholderIds: [],
+    contextTags: [],
+    priority: 0,
+    energy: 'med',
+    createdAt: '',
+    updatedAt: '',
+    source: 'manual',
+  },
+  {
+    id: '2',
+    title: 'tomorrow waiting',
+    status: 'waiting',
+    stakeholderIds: [],
+    contextTags: [],
+    priority: 0,
+    energy: 'med',
+    createdAt: '',
+    updatedAt: '',
+    source: 'manual',
+    dueAt: '2023-07-06',
+  },
+  {
+    id: '3',
+    title: 'next week',
+    status: 'next',
+    stakeholderIds: [],
+    contextTags: [],
+    priority: 0,
+    energy: 'med',
+    createdAt: '',
+    updatedAt: '',
+    source: 'manual',
+    dueAt: '2023-07-10',
+  },
+];
+
+describe('selectors', () => {
+  it('selectToday', () => {
+    const res = selectToday(tasks, base);
+    expect(res.map((t) => t.id)).toEqual(['1']);
+  });
+  it('selectWeek', () => {
+    const res = selectWeek(tasks, base);
+    expect(res.map((t) => t.id)).toEqual(['2']);
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@storage",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module"
+}

--- a/packages/storage/src/db.ts
+++ b/packages/storage/src/db.ts
@@ -1,0 +1,19 @@
+import Dexie, { Table } from 'dexie';
+import { Task, Project, Stakeholder, Risk } from '@core/types';
+
+export class GTDDatabase extends Dexie {
+  tasks!: Table<Task, string>;
+  projects!: Table<Project, string>;
+  stakeholders!: Table<Stakeholder, string>;
+  risks!: Table<Risk, string>;
+
+  constructor() {
+    super('gtd-db');
+    this.version(1).stores({
+      tasks: 'id, status, dueAt, projectId',
+      projects: 'id',
+      stakeholders: 'id',
+      risks: 'id, projectId, score',
+    });
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,3 @@
+export * from './ports';
+export * from './db';
+export * from './repositories';

--- a/packages/storage/src/ports.ts
+++ b/packages/storage/src/ports.ts
@@ -1,0 +1,55 @@
+import {
+  Task,
+  Project,
+  Stakeholder,
+  Risk,
+  ReviewSession,
+  Note,
+  Tag,
+  Attachment,
+} from '@core/types';
+
+export interface TaskRepo {
+  add(task: Task): Promise<void>;
+  all(): Promise<Task[]>;
+}
+
+export interface ProjectRepo {
+  all(): Promise<Project[]>;
+}
+
+export interface StakeholderRepo {
+  all(): Promise<Stakeholder[]>;
+}
+
+export interface RiskRepo {
+  all(): Promise<Risk[]>;
+}
+
+export interface ReviewRepo {
+  all(): Promise<ReviewSession[]>;
+}
+
+export interface NoteRepo {
+  all(): Promise<Note[]>;
+}
+
+export interface TagRepo {
+  all(): Promise<Tag[]>;
+}
+
+export interface AttachmentRepo {
+  all(): Promise<Attachment[]>;
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+export interface IdGenerator {
+  id(): string;
+}
+
+export interface Logger {
+  log(...args: unknown[]): void;
+}

--- a/packages/storage/src/repositories.ts
+++ b/packages/storage/src/repositories.ts
@@ -1,0 +1,32 @@
+import { GTDDatabase } from './db';
+import { TaskRepo, ProjectRepo, StakeholderRepo, RiskRepo } from './ports';
+import { Task, Project, Stakeholder, Risk } from '@core/types';
+
+export const db = new GTDDatabase();
+
+export const taskRepo: TaskRepo = {
+  async add(task: Task) {
+    await db.tasks.put(task);
+  },
+  async all() {
+    return db.tasks.toArray();
+  },
+};
+
+export const projectRepo: ProjectRepo = {
+  async all() {
+    return db.projects.toArray();
+  },
+};
+
+export const stakeholderRepo: StakeholderRepo = {
+  async all() {
+    return db.stakeholders.toArray();
+  },
+};
+
+export const riskRepo: RiskRepo = {
+  async all() {
+    return db.risks.toArray();
+  },
+};

--- a/packages/storage/src/seed.ts
+++ b/packages/storage/src/seed.ts
@@ -1,0 +1,46 @@
+import 'fake-indexeddb/auto';
+import { db } from './repositories';
+
+function id() {
+  return Math.random().toString(36).slice(2);
+}
+
+async function seed() {
+  await db.delete();
+  await db.open();
+
+  const projects = Array.from({ length: 12 }, (_, i) => ({
+    id: id(),
+    name: `Project ${i + 1}`,
+    rag: 'green' as const,
+    milestones: [],
+  }));
+  await db.projects.bulkPut(projects);
+
+  const stakeholders = Array.from({ length: 50 }, (_, i) => ({
+    id: id(),
+    name: `Stakeholder ${i + 1}`,
+    touches: [],
+  }));
+  await db.stakeholders.bulkPut(stakeholders);
+
+  const tasks = Array.from({ length: 200 }, (_, i) => ({
+    id: id(),
+    title: `Task ${i + 1}`,
+    status: 'inbox' as const,
+    projectId: projects[i % projects.length].id,
+    stakeholderIds: [stakeholders[i % stakeholders.length].id],
+    contextTags: [],
+    priority: 0,
+    energy: 'med' as const,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    source: 'manual' as const,
+  }));
+  await db.tasks.bulkPut(tasks);
+
+  console.log('seeded', tasks.length, 'tasks');
+  process.exit(0);
+}
+
+seed();

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - packages/*
+  - apps/*
+  - e2e

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["packages/core/src/*"],
+      "@storage/*": ["packages/storage/src/*"]
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['packages/**/tests/**/*.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold offline-first GTD PWA with React, Zustand and Dexie
- implement core domain models, priority calc, quick-add parser and selectors with tests
- add Dexie repositories, seed script and basic routes with quick-add UI
- move web index.html to app root so Vite injects React preamble
- ensure React preamble loads by importing `@vitejs/plugin-react/preamble` in entry

## Testing
- `pnpm install` (fails: GET https://registry.npmjs.org/@types%2Fnode: Forbidden - 403)
- `pnpm test` (fails: vitest: not found)
- `pnpm e2e` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd902f73d4832f8af3f176f992ebf3